### PR TITLE
Add support for SerialPort flags

### DIFF
--- a/SerialPortLibrary/src/main/java/com/kongqw/serialportlibrary/SerialPortManager.java
+++ b/SerialPortLibrary/src/main/java/com/kongqw/serialportlibrary/SerialPortManager.java
@@ -41,6 +41,10 @@ public class SerialPortManager extends SerialPort {
      * @return 打开是否成功
      */
     public boolean openSerialPort(File device, int baudRate) {
+        return openSerialPort(device, baudRate, 0);
+    }
+
+    public boolean openSerialPort(File device, int baudRate, int flags) {
 
         Log.i(TAG, "openSerialPort: " + String.format("打开串口 %s  波特率 %s", device.getPath(), baudRate));
 
@@ -57,7 +61,7 @@ public class SerialPortManager extends SerialPort {
         }
 
         try {
-            mFd = open(device.getAbsolutePath(), baudRate, 0);
+            mFd = open(device.getAbsolutePath(), baudRate, flags);
             mFileInputStream = new FileInputStream(mFd);
             mFileOutputStream = new FileOutputStream(mFd);
             Log.i(TAG, "openSerialPort: 串口已经打开 " + mFd);


### PR DESCRIPTION
Add support for SerialPort flags in SerialPortManagerjava
SerialPort flags are used in the C library here:
https://github.com/kongqw/AndroidSerialPort/blob/master/SerialPortLibrary/src/main/cpp/SerialPort.c#L98

but SerialPortManager.java has an hardcoded flag of 0
https://github.com/kongqw/AndroidSerialPort/blob/master/SerialPortLibrary/src/main/java/com/kongqw/serialportlibrary/SerialPortManager.java#L60

This PR doesn't break the previous API/interface but instead adds a new function overload/definition